### PR TITLE
Fix PropType Error

### DIFF
--- a/src/lib/components/SkillBar.jsx
+++ b/src/lib/components/SkillBar.jsx
@@ -215,7 +215,7 @@ export default class SkillBar extends Component<Props, State> {
 
 SkillBar.propTypes = {
   skills: PropTypes.arrayOf(PropTypes.shape),
-  colors: PropTypes.shape,
+  colors: PropTypes.object,
   animationDelay: PropTypes.number,
   animationDuration: PropTypes.number,
   offset: PropTypes.number,


### PR DESCRIPTION
Using **react-skillbars**, I get a PropType error from `colors`:

` t: type specification of prop 'colors' is invalid; the type checker function must return 'null' or an 'Error' but returned a function. You may have forgotten to pass an argument to the type checker creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and shape all require an argument).`

Swapping `colors` from `.shape` to `.object` resolves this.