### PR TITLE
Added prop to change color of level and symbol

### DIFF
--- a/packages/docs/docs/intro.md
+++ b/packages/docs/docs/intro.md
@@ -159,3 +159,15 @@ Specifies unit of measure. Accepts strings as input.
 ```javascript
 symbol = {'HP'}
 ```
+
+### Symbol & Level Text Color
+
+Requirement: optional
+
+Default: white
+
+Specifies color of symbol and bar level. Accepts strings of colors or hex codes.
+
+```javascript
+symbolColor = {'white'}
+```

--- a/packages/react-skillbars/src/components/index.ts
+++ b/packages/react-skillbars/src/components/index.ts
@@ -19,6 +19,11 @@ export type SkillBarProps = {
    */
   readonly symbol?: string;
 
+    /**
+   * String object for unit symbol. Default is %.
+   */
+  readonly symbolColor?: string;
+
   /** Global colors object. Applies styling to all bar backgrounds
    */
   readonly barBackground?: string;

--- a/packages/react-skillbars/src/components/skillbar.tsx
+++ b/packages/react-skillbars/src/components/skillbar.tsx
@@ -12,6 +12,7 @@ const SkillBar: FC<SkillBarProps> = ({
   offset = `25px`,
   height = 35,
   symbol = '%',
+  symbolColor = 'white',
   animationDuration = 3000,
   animationDelay = 1000,
   animationThreshold = 0.8,
@@ -116,7 +117,10 @@ const SkillBar: FC<SkillBarProps> = ({
               transition: `width ${animationDuration}ms ease-in-out`,
             }}
           />
-          <div className="skillbar-percent" data-testid={'skillbar/percent'}>
+          <div className="skillbar-percent" data-testid={'skillbar/percent'}
+            style={{
+              color: symbolColor
+            }}>
             {skill.level}
             {symbol}
           </div>


### PR DESCRIPTION
## Description

Added string prop of 'symbolColor' to style the level and symbol in the bar. Currently is white so I set that as the default prop value. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
